### PR TITLE
Harden repository workflows and releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '05:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      nuget-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '05:30'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,23 +32,23 @@ jobs:
 
     steps:
       - name: Checkout full history
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Install .NET SDK
-        uses: actions/setup-dotnet@v5.4.0
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v4.7.0
+        uses: gittools/actions/gitversion/setup@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           versionSpec: 6.8.x
 
       - name: Determine semantic version
         id: gitversion
-        uses: gittools/actions/gitversion/execute@v4.7.0
+        uses: gittools/actions/gitversion/execute@7417b1089e2c7de93510f1901d656ddf60bb024f # v4.7.0
         with:
           configFilePath: GitVersion.yml
           updateAssemblyInfo: false
@@ -134,9 +134,10 @@ jobs:
           INFORMATIONAL_VERSION: ${{ steps.gitversion.outputs.informationalVersion }}
         run: |
           $packageName = "Player.NET-$env:VERSION-win-x64"
+          $assetName = "$packageName.exe"
           $publishDirectory = Join-Path $env:RUNNER_TEMP $packageName
           $artifactDirectory = Join-Path $env:GITHUB_WORKSPACE 'artifacts'
-          $zipPath = Join-Path $artifactDirectory "$packageName.zip"
+          $assetPath = Join-Path $artifactDirectory $assetName
           New-Item -ItemType Directory -Force -Path $publishDirectory | Out-Null
           New-Item -ItemType Directory -Force -Path $artifactDirectory | Out-Null
 
@@ -149,23 +150,28 @@ jobs:
             -nodeReuse:false `
             -warnaserror `
             -p:ContinuousIntegrationBuild=true `
-            -p:PublishSingleFile=false `
+            -p:PublishSingleFile=true `
+            -p:IncludeAllContentForSelfExtract=true `
+            -p:EnableCompressionInSingleFile=true `
             -p:PublishTrimmed=false `
             -p:PublishReadyToRun=false `
+            -p:DebugType=None `
+            -p:DebugSymbols=false `
             -p:Version="$env:VERSION" `
             -p:AssemblyVersion="$env:ASSEMBLY_VERSION" `
             -p:FileVersion="$env:FILE_VERSION" `
             -p:InformationalVersion="$env:INFORMATIONAL_VERSION"
 
-          Compress-Archive -Path (Join-Path $publishDirectory '*') -DestinationPath $zipPath -CompressionLevel Optimal
+          Copy-Item -LiteralPath (Join-Path $publishDirectory 'Player.NET.exe') -Destination $assetPath
           "package_name=$packageName" >> $env:GITHUB_OUTPUT
-          "zip_path=$zipPath" >> $env:GITHUB_OUTPUT
+          "asset_name=$assetName" >> $env:GITHUB_OUTPUT
+          "asset_path=$assetPath" >> $env:GITHUB_OUTPUT
 
       - name: Upload player artifact
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.package.outputs.package_name }}
-          path: ${{ steps.package.outputs.zip_path }}
+          path: ${{ steps.package.outputs.asset_path }}
           if-no-files-found: error
           compression-level: 0
           retention-days: 14
@@ -180,7 +186,7 @@ jobs:
 
     steps:
       - name: Download packaged player
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ needs.build.outputs.package_name }}
           path: release
@@ -191,9 +197,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PACKAGE_NAME: ${{ needs.build.outputs.package_name }}
+          ASSET_NAME: ${{ needs.build.outputs.package_name }}.exe
         run: |
           gh release create "$GITHUB_REF_NAME" \
-            "release/$PACKAGE_NAME.zip#$PACKAGE_NAME.zip" \
+            "release/$ASSET_NAME#$ASSET_NAME" \
             --verify-tag \
             --generate-notes \
             --title "$GITHUB_REF_NAME"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '23 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze C#
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@641a925cfafe92d0fdf8b239ba4053e3f8d99d6d # v3
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: Restore
+        shell: pwsh
+        run: dotnet restore DJPad.sln --runtime win-x64
+
+      - name: Build
+        shell: pwsh
+        run: |
+          dotnet build DJPad.sln `
+            --configuration Release `
+            --no-restore `
+            -nodeReuse:false `
+            -warnaserror `
+            -p:ContinuousIntegrationBuild=true
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@641a925cfafe92d0fdf8b239ba4053e3f8d99d6d # v3
+        with:
+          category: /language:csharp

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,25 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          license-check: true
+          vulnerability-check: true

--- a/DJPad.UI/DJPad.UI.csproj
+++ b/DJPad.UI/DJPad.UI.csproj
@@ -2,12 +2,9 @@
   <PropertyGroup>
     <RootNamespace>DJPad.UI</RootNamespace>
     <AssemblyName>DJPad.UI</AssemblyName>
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAPICodePack-Core" Version="1.1.2" />
-    <PackageReference Include="WindowsAPICodePack-Shell" Version="1.1.1" />
     <PackageReference Include="Vortice.Direct2D1" Version="3.8.3" />
     <PackageReference Include="Vortice.DXGI" Version="3.8.3" />
   </ItemGroup>

--- a/DJPad.UI/WindowsSpecificShell.cs
+++ b/DJPad.UI/WindowsSpecificShell.cs
@@ -3,7 +3,6 @@
     using System.Drawing;
     using DJPad.Core;
     using DJPad.Core.Utils;
-    using Microsoft.WindowsAPICodePack.Taskbar;
     using System;
 
     using Resources;
@@ -11,16 +10,11 @@
 
     public class WindowsSpecificShell
     {
-        private static readonly System.Reflection.MethodInfo SetOverlayIconForHandle = typeof(TaskbarManager).GetMethod(
-            "SetOverlayIcon", new[] { typeof(IntPtr), typeof(Icon), typeof(string) });
-        private static readonly System.Reflection.MethodInfo SetProgressStateForHandle = typeof(TaskbarManager).GetMethod(
-            "SetProgressState", new[] { typeof(TaskbarProgressBarState), typeof(IntPtr) });
-        private static readonly System.Reflection.MethodInfo SetProgressValueForHandle = typeof(TaskbarManager).GetMethod(
-            "SetProgressValue", new[] { typeof(int), typeof(int), typeof(IntPtr) });
+        private static readonly ITaskbarList4 Taskbar = CreateTaskbar();
 
         public void SetOverlayIcon(IntPtr windowHandle, IPlaylistItem item, bool playing)
         {
-            if (item != null && TaskbarManager.IsPlatformSupported && windowHandle != IntPtr.Zero)
+            if (item != null && Taskbar != null && windowHandle != IntPtr.Zero)
             {
                 using var coverArt = (item.SynchronousArt ?? Resources.Unknown).Overlay(
                     playing ? Resources.Player_Play_Small : Resources.Player_Pause_Small,
@@ -28,9 +22,7 @@
                 var iconHandle = coverArt.GetHicon();
                 try
                 {
-                    using var borrowedIcon = Icon.FromHandle(iconHandle);
-                    using var icon = (Icon)borrowedIcon.Clone();
-                    SetOverlayIconForHandle.Invoke(TaskbarManager.Instance, new object[] { windowHandle, icon, item.Metadata.Title });
+                    Taskbar.SetOverlayIcon(windowHandle, iconHandle, item.Metadata.Title);
                 }
                 finally
                 {
@@ -41,19 +33,73 @@
 
         public void SetPlaybackProgress(IntPtr windowHandle, int value, bool playing)
         {
-            if (!TaskbarManager.IsPlatformSupported || windowHandle == IntPtr.Zero)
+            if (Taskbar == null || windowHandle == IntPtr.Zero)
             {
                 return;
             }
 
-            var state = playing ? TaskbarProgressBarState.Normal : TaskbarProgressBarState.Paused;
-            SetProgressStateForHandle.Invoke(TaskbarManager.Instance, new object[] { state, windowHandle });
-            SetProgressValueForHandle.Invoke(TaskbarManager.Instance, new object[] { Math.Clamp(value, 0, 1000), 1000, windowHandle });
+            var state = playing ? TaskbarProgressState.Normal : TaskbarProgressState.Paused;
+            Taskbar.SetProgressState(windowHandle, state);
+            Taskbar.SetProgressValue(windowHandle, (ulong)Math.Clamp(value, 0, 1000), 1000);
+        }
+
+        private static ITaskbarList4 CreateTaskbar()
+        {
+            if (!OperatingSystem.IsWindowsVersionAtLeast(6, 1))
+            {
+                return null;
+            }
+
+            try
+            {
+                var taskbar = (ITaskbarList4)new TaskbarList();
+                return taskbar.HrInit() >= 0 ? taskbar : null;
+            }
+            catch (COMException)
+            {
+                return null;
+            }
         }
 
         [DllImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool DestroyIcon(IntPtr handle);
 
+        private enum TaskbarProgressState : uint
+        {
+            Normal = 2,
+            Paused = 8
+        }
+
+        [ComImport]
+        [Guid("56FDF344-FD6D-11D0-958A-006097C9A090")]
+        private class TaskbarList
+        {
+        }
+
+        [ComImport]
+        [Guid("C43DC798-95D1-4BEA-9030-BB99E2983A1A")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface ITaskbarList4
+        {
+            [PreserveSig] int HrInit();
+            [PreserveSig] int AddTab(IntPtr windowHandle);
+            [PreserveSig] int DeleteTab(IntPtr windowHandle);
+            [PreserveSig] int ActivateTab(IntPtr windowHandle);
+            [PreserveSig] int SetActiveAlt(IntPtr windowHandle);
+            [PreserveSig] int MarkFullscreenWindow(IntPtr windowHandle, [MarshalAs(UnmanagedType.Bool)] bool fullscreen);
+            [PreserveSig] int SetProgressValue(IntPtr windowHandle, ulong completed, ulong total);
+            [PreserveSig] int SetProgressState(IntPtr windowHandle, TaskbarProgressState state);
+            [PreserveSig] int RegisterTab(IntPtr tabHandle, IntPtr parentHandle);
+            [PreserveSig] int UnregisterTab(IntPtr tabHandle);
+            [PreserveSig] int SetTabOrder(IntPtr tabHandle, IntPtr insertBeforeHandle);
+            [PreserveSig] int SetTabActive(IntPtr tabHandle, IntPtr parentHandle, uint reserved);
+            [PreserveSig] int ThumbBarAddButtons(IntPtr windowHandle, uint buttonCount, IntPtr buttons);
+            [PreserveSig] int ThumbBarUpdateButtons(IntPtr windowHandle, uint buttonCount, IntPtr buttons);
+            [PreserveSig] int ThumbBarSetImageList(IntPtr windowHandle, IntPtr imageList);
+            [PreserveSig] int SetOverlayIcon(IntPtr windowHandle, IntPtr iconHandle, [MarshalAs(UnmanagedType.LPWStr)] string description);
+            [PreserveSig] int SetThumbnailTooltip(IntPtr windowHandle, [MarshalAs(UnmanagedType.LPWStr)] string tooltip);
+            [PreserveSig] int SetThumbnailClip(IntPtr windowHandle, IntPtr clip);
+        }
     }
 }

--- a/Player.Avalonia/ClassicPlayerView.cs
+++ b/Player.Avalonia/ClassicPlayerView.cs
@@ -345,7 +345,7 @@ public sealed class ClassicPlayerView : Control
     {
         if (!assets.TryGetValue(name, out var image))
         {
-            using var stream = AssetLoader.Open(new Uri($"avares://DJPad.Experimental/Assets/{Uri.EscapeDataString(name)}"));
+            using var stream = AssetLoader.Open(new Uri($"avares://Player.NET/Assets/{Uri.EscapeDataString(name)}"));
             image = new Bitmap(stream);
             assets[name] = image;
         }

--- a/Player.Avalonia/MainWindow.cs
+++ b/Player.Avalonia/MainWindow.cs
@@ -28,7 +28,7 @@ public sealed class MainWindow : Window
     public MainWindow()
     {
         Title = "Player.NET";
-        using (var iconStream = AssetLoader.Open(new Uri("avares://DJPad.Experimental/Assets/Player.ico")))
+        using (var iconStream = AssetLoader.Open(new Uri("avares://Player.NET/Assets/Player.ico")))
         {
             Icon = new WindowIcon(iconStream);
         }

--- a/Player.Avalonia/MiniPlayerView.cs
+++ b/Player.Avalonia/MiniPlayerView.cs
@@ -208,7 +208,7 @@ public sealed class MiniPlayerView : Control
     {
         if (!assets.TryGetValue(name, out var image))
         {
-            using var stream = AssetLoader.Open(new Uri($"avares://DJPad.Experimental/Assets/{Uri.EscapeDataString(name)}"));
+            using var stream = AssetLoader.Open(new Uri($"avares://Player.NET/Assets/{Uri.EscapeDataString(name)}"));
             image = new Bitmap(stream);
             assets[name] = image;
         }

--- a/Player.Avalonia/PlaylistWindow.cs
+++ b/Player.Avalonia/PlaylistWindow.cs
@@ -151,7 +151,7 @@ internal sealed class PlaylistView : Control
 
         if (unknownArtwork == null)
         {
-            using var stream = AssetLoader.Open(new Uri("avares://DJPad.Experimental/Assets/unknown.jpg"));
+            using var stream = AssetLoader.Open(new Uri("avares://Player.NET/Assets/unknown.jpg"));
             unknownArtwork = new Bitmap(stream);
         }
         return unknownArtwork;

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Player.NET is a compact, artwork-first Windows music player. The current player 
 - Windows 10 or Windows 11 for local development.
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0).
 
-Published `win-x64` release archives are self-contained and do not require a separately installed .NET runtime.
+Published `win-x64` executables are self-contained and do not require a separately installed .NET runtime.
 
 ## Run
 
@@ -55,10 +55,10 @@ dotnet test DJPad.Tests/DJPad.Tests.csproj --configuration Release --filter "Tes
 
 ## Releases
 
-GitVersion calculates semantic versions from the full Git history. Every CI run publishes a versioned, self-contained `win-x64` workflow artifact. Pushing a stable tag such as `v0.1.0` also creates a GitHub release containing:
+GitVersion calculates semantic versions from the full Git history. Every CI run publishes a versioned, self-contained single-file `win-x64` executable. Pushing a stable tag such as `v0.1.0` also creates a GitHub release containing:
 
 ```text
-Player.NET-0.1.0-win-x64.zip
+Player.NET-0.1.0-win-x64.exe
 ```
 
 Release tags must use `vMAJOR.MINOR.PATCH` and point to a commit contained in `master`.


### PR DESCRIPTION
## Summary
- pin all GitHub Actions to immutable commit SHAs and add CodeQL, dependency review, and Dependabot configuration
- publish releases as one self-contained Player.NET.exe
- replace the obsolete Windows API Code Pack taskbar dependency with native Windows COM interop
- correct Avalonia asset URIs for the renamed executable assembly

## Verification
- full Release solution build: 0 warnings, 0 errors
- unit tests: 4 passed, 1 optional audio smoke test skipped
- actionlint: passed
- isolated single-EXE launch: passed after 5-second startup smoke test