### PR TITLE
Add rolling draft releases

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,44 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: '- No user-facing changes'
+
+categories:
+  - title: 'Features'
+    labels:
+      - enhancement
+      - feature
+  - title: 'Fixes'
+    labels:
+      - bug
+      - fix
+  - title: 'Dependencies'
+    labels:
+      - dependencies
+  - title: 'Maintenance'
+    labels:
+      - chore
+      - maintenance
+
+exclude-labels:
+  - skip-changelog
+
+version-resolver:
+  major:
+    labels:
+      - 'release: major'
+  minor:
+    labels:
+      - 'release: minor'
+  patch:
+    labels:
+      - 'release: patch'
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: $PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,13 +176,14 @@ jobs:
           compression-level: 0
           retention-days: 14
 
-  release:
-    name: Publish GitHub release
-    if: github.ref_type == 'tag'
+  draft-release:
+    name: Update draft release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - name: Download packaged player
@@ -191,16 +192,25 @@ jobs:
           name: ${{ needs.build.outputs.package_name }}
           path: release
 
-      - name: Create GitHub release
+      - name: Update release draft
+        id: release-drafter
+        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Replace draft executable
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          PACKAGE_NAME: ${{ needs.build.outputs.package_name }}
+          RELEASE_ID: ${{ steps.release-drafter.outputs.id }}
+          RELEASE_TAG: ${{ steps.release-drafter.outputs.tag_name }}
           ASSET_NAME: ${{ needs.build.outputs.package_name }}.exe
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            "release/$ASSET_NAME#$ASSET_NAME" \
-            --verify-tag \
-            --generate-notes \
-            --title "$GITHUB_REF_NAME"
+          gh api "repos/$GH_REPO/releases/$RELEASE_ID/assets" --jq '.[].id' | while read -r asset_id; do
+            if [[ -n "$asset_id" ]]; then
+              gh api --method DELETE "repos/$GH_REPO/releases/assets/$asset_id"
+            fi
+          done
+
+          gh release upload "$RELEASE_TAG" "release/$ASSET_NAME#$ASSET_NAME"

--- a/README.md
+++ b/README.md
@@ -55,17 +55,12 @@ dotnet test DJPad.Tests/DJPad.Tests.csproj --configuration Release --filter "Tes
 
 ## Releases
 
-GitVersion calculates semantic versions from the full Git history. Every CI run publishes a versioned, self-contained single-file `win-x64` executable. Pushing a stable tag such as `v0.1.0` also creates a GitHub release containing:
+GitVersion calculates semantic versions from the full Git history. Every CI run publishes a versioned, self-contained single-file `win-x64` executable. Each successful build on `master` also updates a rolling draft release containing:
 
 ```text
 Player.NET-0.1.0-win-x64.exe
 ```
 
-Release tags must use `vMAJOR.MINOR.PATCH` and point to a commit contained in `master`.
+Review the draft on the GitHub Releases page and select **Publish release** when it is ready. Publishing creates the `vMAJOR.MINOR.PATCH` tag. Draft versions increment by a patch by default.
 
-```powershell
-git tag -a v0.1.0 -m "Player.NET v0.1.0"
-git push origin v0.1.0
-```
-
-Commit messages can direct the next GitVersion increment with `+semver: major`, `+semver: minor`, `+semver: patch`, or `+semver: none`.
+For a larger increment, apply a `release: minor` or `release: major` label and include the matching `+semver: minor` or `+semver: major` directive in the pull request title. The label versions the draft while the directive versions the executable. `+semver: patch` and `+semver: none` are also supported by GitVersion.


### PR DESCRIPTION
## Summary
- add Release Drafter configuration with categorized notes and semantic version labels
- update each draft only after the master build, tests, and package job succeeds
- replace the draft asset with the latest self-contained single EXE
- remove the duplicate tag-triggered release creation path
- document review and manual publishing from GitHub Releases

## Verification
- actionlint passes for all workflows
- Release Drafter v7.5.1 is pinned to its immutable commit SHA
- the action is present in the repository selected-action allowlist